### PR TITLE
use wasm version without having to change module.exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 var assert = require('nanoassert')
 var b2wasm = require('blake2b-wasm')
 
+var WASM_LOADED = false
+
 // 64-bit unsigned addition
 // Sets v[a,a+1] += v[b,b+1]
 // v should be a Uint32Array
@@ -276,6 +278,10 @@ function toHex (n) {
 var Proto = Blake2b
 
 module.exports = function createHash (outlen, key, salt, personal, noAssert) {
+  if (WASM_LOADED) {
+    return b2wasm(outlen, key, salt, personal, noAssert)
+  }
+
   if (noAssert !== true) {
     assert(outlen >= BYTES_MIN, 'outlen must be at least ' + BYTES_MIN + ', was given ' + outlen)
     assert(outlen <= BYTES_MAX, 'outlen must be at most ' + BYTES_MAX + ', was given ' + outlen)
@@ -317,7 +323,7 @@ var PERSONALBYTES = module.exports.PERSONALBYTES = 16
 
 b2wasm.ready(function (err) {
   if (!err) {
-    module.exports.WASM_LOADED = true
+    WASM_LOADED = module.exports.WASM_LOADED = true
     module.exports = b2wasm
   }
 })


### PR DESCRIPTION
Some bundle tools like rollup and webpack try to convert commonjs to ESM. Since ESM cannot be change the exports dynamically we lost the oportunity of use the wasm version.

This PR add support to allow to use wasm without having to modify exports in the module system behind. 

It's not a breaking change, it doesn't remove the action of modify the exports, it just add another option.