### PR TITLE
support for another object with a compatible API

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,14 +211,14 @@ function Blake2b (outlen, key, salt, personal) {
 }
 
 Blake2b.prototype.update = function (input) {
-  assert(input instanceof Uint8Array, 'input must be Uint8Array or Buffer')
+  assert(input instanceof Uint8Array || input instanceof Buffer, 'input must be Uint8Array or Buffer')
   blake2bUpdate(this, input)
   return this
 }
 
 Blake2b.prototype.digest = function (out) {
   var buf = (!out || out === 'binary' || out === 'hex') ? new Uint8Array(this.outlen) : out
-  assert(buf instanceof Uint8Array, 'out must be "binary", "hex", Uint8Array, or Buffer')
+  assert(buf instanceof Uint8Array || buf instanceof Buffer, 'out must be "binary", "hex", Uint8Array, or Buffer')
   assert(buf.length >= this.outlen, 'out must have at least outlen bytes of space')
   blake2bFinal(this, buf)
   if (out === 'hex') return hexSlice(buf)
@@ -280,16 +280,16 @@ module.exports = function createHash (outlen, key, salt, personal, noAssert) {
     assert(outlen >= BYTES_MIN, 'outlen must be at least ' + BYTES_MIN + ', was given ' + outlen)
     assert(outlen <= BYTES_MAX, 'outlen must be at most ' + BYTES_MAX + ', was given ' + outlen)
     if (key != null) {
-      assert(key instanceof Uint8Array, 'key must be Uint8Array or Buffer')
+      assert(key instanceof Uint8Array || key instanceof Buffer, 'key must be Uint8Array or Buffer')
       assert(key.length >= KEYBYTES_MIN, 'key must be at least ' + KEYBYTES_MIN + ', was given ' + key.length)
       assert(key.length <= KEYBYTES_MAX, 'key must be at most ' + KEYBYTES_MAX + ', was given ' + key.length)
     }
     if (salt != null) {
-      assert(salt instanceof Uint8Array, 'salt must be Uint8Array or Buffer')
+      assert(salt instanceof Uint8Array || salt instanceof Buffer, 'salt must be Uint8Array or Buffer')
       assert(salt.length === SALTBYTES, 'salt must be exactly ' + SALTBYTES + ', was given ' + salt.length)
     }
     if (personal != null) {
-      assert(personal instanceof Uint8Array, 'personal must be Uint8Array or Buffer')
+      assert(personal instanceof Uint8Array || personal instanceof Buffer, 'personal must be Uint8Array or Buffer')
       assert(personal.length === PERSONALBYTES, 'personal must be exactly ' + PERSONALBYTES + ', was given ' + personal.length)
     }
   }


### PR DESCRIPTION
Currently the library doesn't support the stated feature of "All parameters must be Uint8Array, Buffer or another object with a compatible API".

Specifically, if the library is used with the client-side JS, and the Buffer object, while supporting the compatible API, but doesn't extend Uint8Array - the assertions across the library fail.

This PR fixes that by extending the verification to the Buffer object, beyond the Uint8Array.

The PR doesn't impair nor adds complexity to the library and opens it to more general use cases